### PR TITLE
Add support for relative URLs at the meta repo

### DIFF
--- a/src/meta/resolveUrl.spec.ts
+++ b/src/meta/resolveUrl.spec.ts
@@ -1,0 +1,99 @@
+import resolveUrl from "./resolveUrl";
+
+describe("resolveUrl", () => {
+  it("passes through the URL when it's absolute without a base", () => {
+    expect(resolveUrl("scheme://")).toBe("scheme://");
+
+    expect(resolveUrl("https://exmaple.com")).toBe("https://exmaple.com/");
+    expect(resolveUrl("https://exmaple.com/")).toBe("https://exmaple.com/");
+    expect(resolveUrl("https://exmaple.com/qwe")).toBe(
+      "https://exmaple.com/qwe"
+    );
+    expect(resolveUrl("https://exmaple.com/qwe?qwe=rty")).toBe(
+      "https://exmaple.com/qwe?qwe=rty"
+    );
+
+    expect(resolveUrl("file:/my/path")).toBe("file:///my/path");
+  });
+
+  it("passes through the URL when it's absolute and a base URL is set", () => {
+    expect(resolveUrl("scheme://", "https://mybase.exmaple.com")).toBe(
+      "scheme://"
+    );
+
+    expect(
+      resolveUrl("https://exmaple.com", "https://mybase.exmaple.com")
+    ).toBe("https://exmaple.com/");
+    expect(
+      resolveUrl("https://exmaple.com/", "https://mybase.exmaple.com")
+    ).toBe("https://exmaple.com/");
+    expect(
+      resolveUrl("https://exmaple.com/qwe", "https://mybase.exmaple.com")
+    ).toBe("https://exmaple.com/qwe");
+    expect(
+      resolveUrl(
+        "https://exmaple.com/qwe?qwe=rty",
+        "https://mybase.exmaple.com"
+      )
+    ).toBe("https://exmaple.com/qwe?qwe=rty");
+
+    expect(resolveUrl("file:/my/path", "https://mybase.exmaple.com")).toBe(
+      "file:///my/path"
+    );
+  });
+
+  it("handles relative URL correctly a base URL is proided", () => {
+    expect(resolveUrl("", "scheme://")).toBe("scheme://");
+    expect(resolveUrl("", "scheme:/")).toBe("scheme:/");
+
+    expect(resolveUrl("", "https://exmaple.com")).toBe("https://exmaple.com/");
+    expect(resolveUrl("/", "https://exmaple.com")).toBe("https://exmaple.com/");
+    expect(resolveUrl("qwe", "https://exmaple.com")).toBe(
+      "https://exmaple.com/qwe"
+    );
+    expect(resolveUrl("/qwe", "https://exmaple.com")).toBe(
+      "https://exmaple.com/qwe"
+    );
+
+    expect(resolveUrl("", "https://exmaple.com/")).toBe("https://exmaple.com/");
+    expect(resolveUrl("rty", "https://exmaple.com/qwe")).toBe(
+      "https://exmaple.com/rty"
+    );
+    expect(resolveUrl("rty", "https://exmaple.com/qwe?qwe=rty")).toBe(
+      "https://exmaple.com/rty"
+    );
+
+    expect(resolveUrl("qwe?qwe=rty", "https://exmaple.com")).toBe(
+      "https://exmaple.com/qwe?qwe=rty"
+    );
+  });
+
+  it("crashes on relative URL with no base URL", () => {
+    expect(() => {
+      resolveUrl("");
+    }).toThrowError();
+
+    expect(() => {
+      resolveUrl("/");
+    }).toThrowError();
+
+    expect(() => {
+      resolveUrl("/qwe");
+    }).toThrowError();
+  });
+
+  it("crashes on invalid URL concatenation", () => {
+    expect(() => {
+      resolveUrl("", "scheme:");
+    }).toThrowError();
+    expect(() => {
+      resolveUrl("/", "scheme:");
+    }).toThrowError();
+    expect(() => {
+      resolveUrl("qwe", "scheme:");
+    }).toThrowError();
+    expect(() => {
+      resolveUrl("/qwe", "scheme:");
+    }).toThrowError();
+  });
+});

--- a/src/meta/resolveUrl.ts
+++ b/src/meta/resolveUrl.ts
@@ -1,0 +1,4 @@
+const resolveUrl = (url: string, baseUrl?: string): string =>
+  new URL(url, baseUrl).toString();
+
+export default resolveUrl;

--- a/tests/MetaRepo/logic.ts
+++ b/tests/MetaRepo/logic.ts
@@ -17,7 +17,7 @@ describe("Logic", () => {
     });
 
     const metaRepo = new MetaRepo(
-      makeAxios({ url: server.getURL().toString() }),
+      { getMeta: makeAxios({ url: server.getURL().toString() }) },
       {},
       "0.1.0",
       "win32",
@@ -37,7 +37,7 @@ describe("Logic", () => {
     });
 
     const metaRepo = new MetaRepo(
-      makeAxios({ url: server.getURL().toString() }),
+      { getMeta: makeAxios({ url: server.getURL().toString() }) },
       {},
       "0.1.1",
       "win32",
@@ -57,7 +57,7 @@ describe("Logic", () => {
     });
 
     const metaRepo = new MetaRepo(
-      makeAxios({ url: server.getURL().toString() }),
+      { getMeta: makeAxios({ url: server.getURL().toString() }) },
       {},
       "0.1.0",
       "win32",
@@ -77,7 +77,7 @@ describe("Logic", () => {
     });
 
     const metaRepo = new MetaRepo(
-      makeAxios({ url: server.getURL().toString() }),
+      { getMeta: makeAxios({ url: server.getURL().toString() }) },
       {},
       "0.1.2",
       "win32",

--- a/tests/MetaRepo/transport/axios.ts
+++ b/tests/MetaRepo/transport/axios.ts
@@ -15,7 +15,7 @@ describe("Transport - axios", () => {
     });
 
     const metaRepo = new MetaRepo(
-      makeAxios({ url: server.getURL().toString() }),
+      { getMeta: makeAxios({ url: server.getURL().toString() }) },
       {},
       "0.1.0",
       "win32",
@@ -36,7 +36,7 @@ describe("Transport - axios", () => {
     });
 
     const metaRepo = new MetaRepo(
-      makeAxios({ url: server.getURL().toString() }),
+      { getMeta: makeAxios({ url: server.getURL().toString() }) },
       {},
       "0.1.0",
       "win32",
@@ -57,7 +57,7 @@ describe("Transport - axios", () => {
     });
 
     const metaRepo = new MetaRepo(
-      makeAxios({ url: server.getURL().toString() }),
+      { getMeta: makeAxios({ url: server.getURL().toString() }) },
       {},
       "0.1.0",
       "win32",
@@ -78,7 +78,7 @@ describe("Transport - axios", () => {
     });
 
     const metaRepo = new MetaRepo(
-      makeAxios({ url: server.getURL().toString() }),
+      { getMeta: makeAxios({ url: server.getURL().toString() }) },
       {},
       "0.1.0",
       "win32",
@@ -99,7 +99,7 @@ describe("Transport - axios", () => {
     });
 
     const metaRepo = new MetaRepo(
-      makeAxios({ url: server.getURL().toString() }),
+      { getMeta: makeAxios({ url: server.getURL().toString() }) },
       {},
       "0.1.0",
       "win32",
@@ -120,7 +120,7 @@ describe("Transport - axios", () => {
     });
 
     const metaRepo = new MetaRepo(
-      makeAxios({ url: server.getURL().toString() }),
+      { getMeta: makeAxios({ url: server.getURL().toString() }) },
       {},
       "0.1.0",
       "win32",


### PR DESCRIPTION
This PR implements support for using relative feed URLs in the meta repos.

If the `baseUrl` is set in the provider, the URLs in the meta repo will be resolved via that base URL.

Examples:

URL | Base | Result
--- | --- | ---
empty string | `https://example.com` | `https://example.com/`
`/` | `https://example.com` | `https://example.com/`
`qwe` | `https://example.com` | `https://example.com/qwe`
`/qwe` | `https://example.com` | `https://example.com/qwe`
empty string | `https://example.com/subpath` | `https://example.com/`
`/` | `https://example.com/subpath` | `https://example.com/`
`qwe` | `https://example.com/subpath` | `https://example.com/qwe`
`/qwe` | `https://example.com/subpath` | `https://example.com/qwe`